### PR TITLE
Scroll to scale

### DIFF
--- a/block_20x_20_.tscn
+++ b/block_20x_20_.tscn
@@ -2,9 +2,7 @@
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_wgua8"]
 
-[node name="Block_20x20_" type="StaticBody2D"]
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+[node name="CollisionShape2D" type="CollisionShape2D"]
 shape = SubResource("RectangleShape2D_wgua8")
 
 [node name="ColorRect" type="ColorRect" parent="."]

--- a/controller.gd
+++ b/controller.gd
@@ -8,32 +8,31 @@ var scale_factor := 500.0
 func _ready():
 	pass # Replace with function body.
 
-var original_transform := Transform2D.IDENTITY
 var scale_origin := Vector2.ZERO
-var local_scale_origin:Vector2
+var original_scale := 0.0
 var is_scaling := false
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _physics_process(delta):
 	
 	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
 		var current_cursor_pos := get_viewport().get_mouse_position()
 		if !is_scaling:
 			scale_origin = current_cursor_pos
-			original_transform = $ScalableRoomInner.global_transform
+			# Assumes equal x and y scale
+			assert($ScalableRoomInner.global_transform.get_scale().x ==
+				$ScalableRoomInner.global_transform.get_scale().y)
+			original_scale = $ScalableRoomInner.get_current_linear_scale()
 			is_scaling = true
 		else:
 			var scale_distance := -(current_cursor_pos.y - scale_origin.y) / scale_factor
-			var scale_val := pow(2, scale_distance)
-			#TODO: Actually change center of scaling
-			var scaled_transform := original_transform.scaled(Vector2.ONE * scale_val)
 			
-			var adjusted_origin := scaled_transform * (original_transform.affine_inverse() * scale_origin)
+			var current_scale:float = $ScalableRoomInner.get_current_linear_scale()
 			
-			var origin_offset := adjusted_origin - scale_origin
+			var current_distance := current_scale - original_scale
 			
-			var final_transform := scaled_transform.translated(-origin_offset)
+			var distance_to_go := scale_distance - current_distance
 			
-			$ScalableRoomInner.global_transform = final_transform
+			$ScalableRoomInner.linear_scale_from(scale_origin, distance_to_go)
 	else:
 		is_scaling = false

--- a/controller.gd
+++ b/controller.gd
@@ -1,8 +1,16 @@
 extends Node2D
 
 @export
-## The distance which corresponds to doubling or halving the scale
-var scale_factor := 500.0
+## The amount scaled per scroll
+var scale_step := 0.3
+@export
+## The strength of the scale smoothing
+## Note that this corresponds to an exponential decay from the current scale to the target,
+##  meaning it is not really an exact speed, but rather just determines how steep the decay is,
+##  but the exact speed will be dependent on the current distance to the target
+var scale_strength := 5.0
+@export
+var max_scale_speed := 0.2
 
 @export
 ## The node to apply transform controls to by default
@@ -10,7 +18,10 @@ var transform_target:Transformable
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
+	# Assumes equal x and y scale
+	assert(transform_target.global_transform.get_scale().x ==
+		transform_target.global_transform.get_scale().y)
+	target_scale = transform_target.get_current_linear_scale()
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -19,32 +30,44 @@ func _physics_process(delta):
 	handle_translation(delta)
 	handle_rotation(delta)
 
+#var original_scale := 0.0
+
+var target_scale:float = 0.0
+var scale_direction:int = 0
 var scale_origin := Vector2.ZERO
-var original_scale := 0.0
-var is_scaling := false
+
+## Temporary HACK until we actually stop the ball from clipping in #4 (https://github.com/Zshandi/ScalingPuzzler/issues/4)
+var min_scale := -1.2
 
 func handle_scaling(delta):
-	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
-		var current_cursor_pos := get_viewport().get_mouse_position()
-		if !is_scaling:
-			scale_origin = current_cursor_pos
-			# Assumes equal x and y scale
-			assert(transform_target.global_transform.get_scale().x ==
-				transform_target.global_transform.get_scale().y)
-			original_scale = transform_target.get_current_linear_scale()
-			is_scaling = true
-		else:
-			var scale_distance := -(current_cursor_pos.y - scale_origin.y) / scale_factor
-			
-			var current_scale:float = transform_target.get_current_linear_scale()
-			
-			var current_distance := current_scale - original_scale
-			
-			var distance_to_go := scale_distance - current_distance
-			
-			transform_target.linear_scale_from(scale_origin, distance_to_go)
-	else:
-		is_scaling = false
+	var current_scale:float = transform_target.get_current_linear_scale()
+	
+	if Input.is_action_just_pressed("control_scale_up"):
+		target_scale += scale_step
+		scale_origin = get_viewport().get_mouse_position()
+	if Input.is_action_just_pressed("control_scale_down"):
+		target_scale -= scale_step
+		scale_origin = get_viewport().get_mouse_position()
+	
+	if target_scale != current_scale:
+		var target_scale_direction = 1 if target_scale > 0 else -1
+		
+		# Get new scale (exp decay to target)
+		var scale_to := lerpf(current_scale, target_scale, delta * scale_strength)
+		
+		## Temporary HACK until we actually stop the ball from clipping in #4 (https://github.com/Zshandi/ScalingPuzzler/issues/4)
+		if scale_to < min_scale:
+			scale_to = min_scale
+			target_scale = min_scale
+		
+		# Scale to that scale
+		var scale_by := scale_to - current_scale
+		
+		# Limit scaling speed
+		scale_by = max(-max_scale_speed, scale_by)
+		scale_by = min(max_scale_speed, scale_by)
+		
+		transform_target.linear_scale_from(scale_origin, scale_by)
 
 func handle_translation(delta):
 	pass

--- a/controller.gd
+++ b/controller.gd
@@ -4,6 +4,10 @@ extends Node2D
 ## The distance which corresponds to doubling or halving the scale
 var scale_factor := 500.0
 
+@export
+## The node to apply transform controls to by default
+var transform_target:Transformable
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	pass # Replace with function body.
@@ -25,20 +29,20 @@ func handle_scaling(delta):
 		if !is_scaling:
 			scale_origin = current_cursor_pos
 			# Assumes equal x and y scale
-			assert($ScalableRoomInner.global_transform.get_scale().x ==
-				$ScalableRoomInner.global_transform.get_scale().y)
-			original_scale = $ScalableRoomInner.get_current_linear_scale()
+			assert(transform_target.global_transform.get_scale().x ==
+				transform_target.global_transform.get_scale().y)
+			original_scale = transform_target.get_current_linear_scale()
 			is_scaling = true
 		else:
 			var scale_distance := -(current_cursor_pos.y - scale_origin.y) / scale_factor
 			
-			var current_scale:float = $ScalableRoomInner.get_current_linear_scale()
+			var current_scale:float = transform_target.get_current_linear_scale()
 			
 			var current_distance := current_scale - original_scale
 			
 			var distance_to_go := scale_distance - current_distance
 			
-			$ScalableRoomInner.linear_scale_from(scale_origin, distance_to_go)
+			transform_target.linear_scale_from(scale_origin, distance_to_go)
 	else:
 		is_scaling = false
 

--- a/controller.gd
+++ b/controller.gd
@@ -8,13 +8,18 @@ var scale_factor := 500.0
 func _ready():
 	pass # Replace with function body.
 
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _physics_process(delta):
+	handle_scaling(delta)
+	handle_translation(delta)
+	handle_rotation(delta)
+
 var scale_origin := Vector2.ZERO
 var original_scale := 0.0
 var is_scaling := false
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _physics_process(delta):
-	
+func handle_scaling(delta):
 	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
 		var current_cursor_pos := get_viewport().get_mouse_position()
 		if !is_scaling:
@@ -36,3 +41,9 @@ func _physics_process(delta):
 			$ScalableRoomInner.linear_scale_from(scale_origin, distance_to_go)
 	else:
 		is_scaling = false
+
+func handle_translation(delta):
+	pass
+
+func handle_rotation(delta):
+	pass

--- a/level.tscn
+++ b/level.tscn
@@ -10,8 +10,9 @@
 position = Vector2(527, 321)
 script = ExtResource("1_hs6ep")
 
-[node name="ScalableRoomInner" type="Node2D" parent="ControllingRoom"]
+[node name="ScalableRoomInner" type="StaticBody2D" parent="ControllingRoom"]
 rotation = 3.14159
+metadata/_edit_group_ = true
 
 [node name="Block_20x20_" parent="ControllingRoom/ScalableRoomInner" instance=ExtResource("1_nkas4")]
 position = Vector2(-110, -103)

--- a/level.tscn
+++ b/level.tscn
@@ -7,9 +7,10 @@
 
 [node name="Level" type="Node2D"]
 
-[node name="ControllingRoom" type="Node2D" parent="."]
+[node name="ControllingRoom" type="Node2D" parent="." node_paths=PackedStringArray("transform_target")]
 position = Vector2(527, 321)
 script = ExtResource("1_hs6ep")
+transform_target = NodePath("ScalableRoomInner")
 
 [node name="ScalableRoomInner" type="StaticBody2D" parent="ControllingRoom"]
 rotation = 3.14159

--- a/level.tscn
+++ b/level.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://d1dxk3g6y2oei"]
+[gd_scene load_steps=5 format=3 uid="uid://d1dxk3g6y2oei"]
 
 [ext_resource type="Script" path="res://controller.gd" id="1_hs6ep"]
 [ext_resource type="PackedScene" uid="uid://cxtn3jpr3d1ax" path="res://block_20x_20_.tscn" id="1_nkas4"]
+[ext_resource type="Script" path="res://transformable.gd" id="2_rhtag"]
 [ext_resource type="PackedScene" uid="uid://gcfibrlv71gp" path="res://ball.tscn" id="3_lp4p4"]
 
 [node name="Level" type="Node2D"]
@@ -12,6 +13,7 @@ script = ExtResource("1_hs6ep")
 
 [node name="ScalableRoomInner" type="StaticBody2D" parent="ControllingRoom"]
 rotation = 3.14159
+script = ExtResource("2_rhtag")
 metadata/_edit_group_ = true
 
 [node name="Block_20x20_" parent="ControllingRoom/ScalableRoomInner" instance=ExtResource("1_nkas4")]

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,29 @@ run/main_scene="res://level.tscn"
 config/features=PackedStringArray("4.3", "Mobile")
 config/icon="res://icon.svg"
 
+[input]
+
+control_scale_up={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":4,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+control_scale_down={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":5,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+control_translate_activate={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+control_rotate_activate={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+
 [rendering]
 
 renderer/rendering_method="mobile"

--- a/transformable.gd
+++ b/transformable.gd
@@ -1,0 +1,43 @@
+extends Node2D
+class_name Transformable
+
+# Utility helper function, may want to move to static library
+func based_log(base:float = 10, x:float = 10) -> float:
+	return (log(x) / log(base))
+
+func get_current_linear_scale(axis:int = Vector2.AXIS_X) -> float:
+	return based_log(2, global_transform.get_scale()[axis])
+
+
+
+func linear_scale_from(center:Vector2, linear_scale_by:float):
+	# Convenience: go from float to vector
+	linear_scale_from_vec(center, Vector2.ONE * linear_scale_by)
+
+func linear_scale_from_vec(center:Vector2, linear_scale_by:Vector2):
+	# Convert linear to exponential scaling:
+	# 0 = 1x, 1 = 2x, 2 = 4x, -1 = 0.5x, etc.
+	var scale_by := Vector2(pow(2, linear_scale_by.x), pow(2, linear_scale_by.y))
+	scale_from_vec(center, scale_by)
+
+func scale_from(center:Vector2, scale_by:float):
+	# Convenience: go from float to vector
+	scale_from_vec(center, Vector2.ONE * scale_by)
+
+func scale_from_vec(center:Vector2, scale_by:Vector2):
+	# Get original transform for reference
+	var original_transform := global_transform
+	
+	# Simply scale the transform to start
+	var scaled_transform := original_transform.scaled(scale_by)
+	
+	# Get scaled center position:
+	#  1. apply inverse of original transform to get center with no transform (i.e. Identity)
+	#  2. apply new transform to get new center
+	var adjusted_center := scaled_transform * (original_transform.affine_inverse() * center)
+	
+	# Get the difference from original center, so we can counteract this in the final transform
+	var center_offset := adjusted_center - center
+	
+	# Subtract the offset, to counter center point movement from scaling
+	global_transform = scaled_transform.translated(-center_offset)


### PR DESCRIPTION
Update to allow scrolling in order to scale

Moves actual scaling logic to new `Transformable` class

Also limits size a temporary solution to the ball clipping when the scale it too small