### PR TITLE
13 add camera panning with wasd + center to ball shortcut with c

### DIFF
--- a/camera_2d.gd
+++ b/camera_2d.gd
@@ -1,0 +1,37 @@
+extends Camera2D
+
+@export
+var pan_max_speed := 50.0
+@export
+var pan_accel := 35.0
+@export
+var pan_brake := 45.0
+
+var pan_speed := Vector2.ZERO
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	
+	var x_pan := Input.get_axis("camera_pan_left", "camera_pan_right")
+	var y_pan := Input.get_axis("camera_pan_up", "camera_pan_down")
+	
+	adjust_pan_axis(x_pan, Vector2.AXIS_X, delta)
+	adjust_pan_axis(y_pan, Vector2.AXIS_Y, delta)
+	
+	global_position += pan_speed
+
+func adjust_pan_axis(pan_axis_val:float, pan_axis:int, delta:float):
+	var target_speed := pan_axis_val * pan_max_speed
+	
+	var accel := pan_accel
+	if target_speed == 0:
+		accel = pan_brake
+	elif (target_speed < 0) != (pan_speed[pan_axis] < 0):
+		accel += pan_brake
+	
+	pan_speed[pan_axis] = move_toward(pan_speed[pan_axis], target_speed, accel * delta)

--- a/camera_2d.gd
+++ b/camera_2d.gd
@@ -1,29 +1,46 @@
 extends Camera2D
 
 @export
-var pan_max_speed := 50.0
+var pan_max_speed:float = 50.0
 @export
-var pan_accel := 35.0
+var pan_accel:float = 35.0
 @export
-var pan_brake := 45.0
+var pan_brake:float = 45.0
+
+@export
+var pan_center_duration:float = 1.0
+@export
+var pan_center_trans := Tween.TRANS_CUBIC
 
 var pan_speed := Vector2.ZERO
 
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
-	pass # Replace with function body.
+var pan_to_center:bool = false
 
+var current_center_pan_tween:Tween = null
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
 	
-	var x_pan := Input.get_axis("camera_pan_left", "camera_pan_right")
-	var y_pan := Input.get_axis("camera_pan_up", "camera_pan_down")
+	if Input.is_action_just_pressed("camera_pan_center"):
+		if current_center_pan_tween != null:
+			current_center_pan_tween.stop()
+		pan_to_center = true
+		
+		var pan_to:Vector2 = $"../Ball".global_position - get_viewport_rect().size / 2
+		
+		current_center_pan_tween = create_tween()
+		current_center_pan_tween.set_trans(pan_center_trans)
+		current_center_pan_tween.tween_property(self, "global_position", pan_to, pan_center_duration)
+		current_center_pan_tween.tween_property(self, "pan_to_center", false, 0.0)
+		current_center_pan_tween.play()
 	
-	adjust_pan_axis(x_pan, Vector2.AXIS_X, delta)
-	adjust_pan_axis(y_pan, Vector2.AXIS_Y, delta)
-	
-	global_position += pan_speed
+	if !pan_to_center:
+		var x_pan := Input.get_axis("camera_pan_left", "camera_pan_right")
+		var y_pan := Input.get_axis("camera_pan_up", "camera_pan_down")
+		
+		adjust_pan_axis(x_pan, Vector2.AXIS_X, delta)
+		adjust_pan_axis(y_pan, Vector2.AXIS_Y, delta)
+		
+		global_position += pan_speed
 
 func adjust_pan_axis(pan_axis_val:float, pan_axis:int, delta:float):
 	var target_speed := pan_axis_val * pan_max_speed

--- a/controller.gd
+++ b/controller.gd
@@ -64,10 +64,10 @@ func handle_scaling(delta):
 	
 	if Input.is_action_just_pressed("control_scale_up"):
 		target_scale += scale_step
-		scale_origin = get_viewport().get_mouse_position()
+		scale_origin = get_cursor_pos()
 	if Input.is_action_just_pressed("control_scale_down"):
 		target_scale -= scale_step
-		scale_origin = get_viewport().get_mouse_position()
+		scale_origin = get_cursor_pos()
 	
 	if target_scale != current_scale:
 		var target_scale_direction = 1 if target_scale > 0 else -1
@@ -102,7 +102,7 @@ var translate_origin_offset := Vector2.ZERO
 var translate_target := Vector2.ZERO
 
 func handle_translation(delta):
-	var cursor_pos := get_viewport().get_mouse_position()
+	var cursor_pos := get_cursor_pos()
 	var translate_current := transform_target.global_position
 	
 	if Input.is_action_pressed("control_translate_activate"):
@@ -141,3 +141,6 @@ func handle_translation(delta):
 
 func handle_rotation(delta):
 	pass
+
+func get_cursor_pos() -> Vector2:
+	return get_viewport().get_mouse_position() + get_viewport().get_camera_2d().global_position

--- a/level.tscn
+++ b/level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://d1dxk3g6y2oei"]
+[gd_scene load_steps=11 format=3 uid="uid://d1dxk3g6y2oei"]
 
 [ext_resource type="Script" path="res://controller.gd" id="1_hs6ep"]
 [ext_resource type="Script" path="res://transformable.gd" id="2_rhtag"]
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://cgsyv55s3of86" path="res://scrolling_background.tscn" id="5_tcym5"]
 [ext_resource type="Texture2D" uid="uid://qwua243tgxlc" path="res://assets/backgrounds/background_blue.png" id="6_02fwp"]
 [ext_resource type="AudioStream" uid="uid://dlemxkelfiipd" path="res://assets/music/Trouble Makers (Loopable).wav" id="7_8i2ys"]
+[ext_resource type="Script" path="res://camera_2d.gd" id="9_r5gpm"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_2rvfl"]
 shader = ExtResource("3_rrem5")
@@ -44,3 +45,7 @@ background = ExtResource("6_02fwp")
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource("7_8i2ys")
 autoplay = true
+
+[node name="Camera2D" type="Camera2D" parent="."]
+anchor_mode = 0
+script = ExtResource("9_r5gpm")

--- a/project.godot
+++ b/project.godot
@@ -37,6 +37,31 @@ control_rotate_activate={
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
+camera_pan_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
+]
+}
+camera_pan_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
+]
+}
+camera_pan_up={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
+]
+}
+camera_pan_down={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
+]
+}
+camera_pan_center={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":67,"key_label":0,"unicode":99,"location":0,"echo":false,"script":null)
+]
+}
 
 [rendering]
 

--- a/project.godot
+++ b/project.godot
@@ -62,6 +62,11 @@ camera_pan_center={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":67,"key_label":0,"unicode":99,"location":0,"echo":false,"script":null)
 ]
 }
+camera_pan_center_lock={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":88,"key_label":0,"unicode":120,"location":0,"echo":false,"script":null)
+]
+}
 
 [rendering]
 

--- a/scrolling_background.gd
+++ b/scrolling_background.gd
@@ -15,8 +15,8 @@ func _ready():
 	var sprite_width = scrolling_sprite.texture.get_width()
 	var sprite_height = scrolling_sprite.texture.get_height()
 	
-	var width_scale_multiplier = floor((100.0 / sprite_width) * 15)
-	var height_scale_multiplier = floor((100.0 / sprite_height) * 15)
+	var width_scale_multiplier = floor((200.0 / sprite_width) * 15)
+	var height_scale_multiplier = floor((200.0 / sprite_height) * 15)
 
 	var size_to_use = Vector2(
 		sprite_width*width_scale_multiplier,


### PR DESCRIPTION
Add Camera Controls (panning & centering)
Make panning work with regular controls (account for camera position)
Fix scrolling background somehow (was not updating properly when panning to the right)

Camera controls:

Regular pan up/left/down/right: W/A/S/D
Pan to center of ball: C
Lock camera to center of ball: X